### PR TITLE
[update]初めに部屋に入ったプレイヤーしか株が上がらない問題を修正、不必要なDebug.Logや関数を削除

### DIFF
--- a/Assets/Maeda/PlayerUIManager.cs
+++ b/Assets/Maeda/PlayerUIManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using Photon.Pun;
+using System;
 
 public class PlayerUIManager : MonoBehaviour
 {
@@ -110,24 +111,7 @@ public class PlayerUIManager : MonoBehaviour
             if (_playerNickName[i] != null) 
             {
                 _playerNickName[i].text = _playerArray[i].NickName;
-                Debug.Log(_playerArray[i].NickName);
-                PlayerNumberGet();
             }
         }
-    }
-
-    /// <summary>自分のプレイヤーリストでのIndexを取得/// </summary>
-    public int PlayerNumberGet()
-    {
-        for (int i = 0; i < _playerArray.Length; i++)
-        {
-            if (_playerArray[i].NickName == PhotonNetwork.LocalPlayer.NickName)
-            {
-                Debug.Log("localPlayerNumber: " + i);
-                return i;
-            }
-        }
-        Debug.Log("localPlayerNumber: null");
-        return -1;
     }
 }

--- a/Assets/Scripts/Game/BoardManager.cs
+++ b/Assets/Scripts/Game/BoardManager.cs
@@ -43,7 +43,7 @@ public class BoardManager : MonoBehaviour
     public void ChangeStockPrice(int targetPlayer, int price)
     {
         // 「いくらに移動するか」のターゲットとなるオブジェクト（アンカー）を探し、駒をその子オブジェクトにすることで移動させる
-        var targetAnchor = Array.Find<RectTransform>(_priceTable, x => x.name == $"Price {targetPlayer} {price}");
+        var targetAnchor = Array.Find(_priceTable, x => x.name == $"Price {targetPlayer} {price}");
         _marker[targetPlayer].transform.position = targetAnchor.transform.position; //子オブジェクトでは無く位置に移動させている
     }
 

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -110,7 +110,7 @@ public class GameManager : MonoBehaviour, IPunTurnManagerCallbacks
     /// <param name="targetPrice">この値に株価を変更する</param>
     void ChangeStockPrice(int playerIndex, int[] targetPrice)
     {
-        print($"Raise player {playerIndex}'s stock to {targetPrice}");
+        print($"Raise player {playerIndex}'s stock to {targetPrice[0]}");
         _boardManager.ChangeStockPrice(playerIndex, targetPrice[0]);
     }
 
@@ -179,7 +179,7 @@ public class GameManager : MonoBehaviour, IPunTurnManagerCallbacks
     /// </summary>
     public void RaiseStock(bool finished = true)
     {
-            _stockPrice[_playerIndex]+= 1;
+            _stockPrice[0]+= 1;
             MoveStockPrice(true);
     }
 


### PR DESCRIPTION
#37
部屋を立てたマスターのみしか株が上がらない問題をGameManagerで修正。
PlayerUIManagerの不必要なDebug.Logや関数を削除
BoadManagerを一部修正